### PR TITLE
added iron-iconset-svg dependency to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,6 +32,7 @@
     "iron-selector": "PolymerElements/iron-selector#^1.0.8",
     "neon-animation": "PolymerElements/neon-animation#^1.0.0",
     "paper-icon-button": "PolymerElements/paper-icon-button#^1.0.6",
+    "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.9",
     "intl": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`app-datepicker.html`
imports `app-datepicker-icons.html`
  which imports `iron-iconset-svg.html`

however `iron-iconset-svg.html` was missing from `bower.json`